### PR TITLE
Update meta.yaml for 0.8 release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: ibis-framework
-  version: "0.8.0"
+  version: "0.8.1"
 
 source:
-  fn: ibis-framework-0.8.0.tar.gz
-  url: https://pypi.python.org/packages/source/i/ibis-framework/ibis-framework-0.8.0.tar.gz
-  md5: fc28357db5f14c3dfa54ce9d569b0739
+  fn: ibis-framework-0.8.1.tar.gz
+  url: https://pypi.python.org/packages/source/i/ibis-framework/ibis-framework-0.8.1.tar.gz
+  md5: 18cda0ac0d0f7fc2d69798ca7ed0300d
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - pytest
     - numpy >=1.7.0
     - pandas >=0.12.0
-    - impyla >=0.13.7
+    - impyla >=0.13.8
     - python-hdfs >=2.0.0
     - sqlalchemy >=1.0.0
     - six
@@ -29,7 +29,7 @@ requirements:
     - pytest
     - numpy >=1.7.0
     - pandas >=0.12.0
-    - impyla >=0.13.7
+    - impyla >=0.13.8
     - python-hdfs >=2.0.0
     - sqlalchemy >=1.0.0
     - six

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: ibis-framework
-  version: "0.7.1"
+  version: "0.8.0"
 
 source:
-  fn: ibis-framework-0.7.1.tar.gz
-  url: https://pypi.python.org/packages/source/i/ibis-framework/ibis-framework-0.7.1.tar.gz
-  md5: 2b57e8a68cab182554fc7be7d0774f32
+  fn: ibis-framework-0.8.0.tar.gz
+  url: https://pypi.python.org/packages/source/i/ibis-framework/ibis-framework-0.8.0.tar.gz
+  md5: fc28357db5f14c3dfa54ce9d569b0739
 
 build:
   number: 0
@@ -18,7 +18,7 @@ requirements:
     - pytest
     - numpy >=1.7.0
     - pandas >=0.12.0
-    - impyla >=0.13.6
+    - impyla >=0.13.7
     - python-hdfs >=2.0.0
     - sqlalchemy >=1.0.0
     - six
@@ -29,10 +29,11 @@ requirements:
     - pytest
     - numpy >=1.7.0
     - pandas >=0.12.0
-    - impyla >=0.13.6
+    - impyla >=0.13.7
     - python-hdfs >=2.0.0
     - sqlalchemy >=1.0.0
     - six
+    - toolz
     - mock  # [py<35]
 
 test:
@@ -66,3 +67,4 @@ about:
 extra:
   recipe-maintainers:
     - mariusvniekerk
+    - wesm

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   fn: ibis-framework-0.8.1.tar.gz
-  url: https://pypi.python.org/packages/source/i/ibis-framework/ibis-framework-0.8.1.tar.gz
+  url: https://pypi.io/packages/source/i/ibis-framework/ibis-framework-0.8.1.tar.gz
   md5: 18cda0ac0d0f7fc2d69798ca7ed0300d
 
 build:


### PR DESCRIPTION
This is a major release. Depends on conda-forge/impyla#4
