### PR TITLE
Moving OmniSci module again

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,7 +63,7 @@ test:
     - ibis.file.hdf5
     - ibis.impala
     - ibis.sql.mysql
-    - ibis.omniscidb  # [py<38]
+    - ibis.backends.omniscidb  # [py<38]
     - ibis.pandas
     - ibis.sql.postgres
     - ibis.pyspark  # [py<38]


### PR DESCRIPTION
This was implemented in #47, and reverted in #48 to fix the bigquery dependencies problem.