### PR TITLE
Add backend specific conda packages

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -63,10 +63,10 @@ outputs:
         - clickhouse-sqlalchemy
         - geoalchemy2
         - geopandas
-        - impyla >=0.15.0
+        - impyla >=0.17
         - lz4
-        - psycopg2
-        - pyarrow >=0.15
+        - psycopg2 >=2.7
+        - pyarrow >=1.0
         - pymysql
         - pyspark >=2.4.3
         - pytables >=3.0.0
@@ -75,7 +75,7 @@ outputs:
         - python-hdfs >=2.0.16
         - requests
         - shapely
-        - sqlalchemy >=1.1
+        - sqlalchemy >=1.3
         - thrift >=0.11
         - thriftpy2
         - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 1c2266429123c9730307d75e1c2a778e4b9193c8c6d183a12b74c556a8ef9e3f
 
 build:
-  number: 3
+  number: 4
 
 outputs:
   - name: {{ name }}-core
@@ -94,6 +94,202 @@ outputs:
         - ibis.backends.pyspark
         - ibis.backends.sqlite
 
+
+  - name: ibis-clickhouse
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - clickhouse-driver >=0.1.3
+        - clickhouse-cityhash  # [not win]
+        - clickhouse-sqlalchemy >=0.1.4
+        - sqlalchemy >=1.3
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.clickhouse
+
+  - name: ibis-dask
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - lz4
+        - pyarrow >=1
+        - dask >=2021.2.0
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.dask
+
+  - name: ibis-hdf5
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - pytables >=3.0.0
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.hdf5
+
+  - name: ibis-impala
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - impyla >=0.15.0
+        - python-hdfs >=2.0.16
+        - requests
+        - sqlalchemy >=1.3
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.impala
+
+  - name: ibis-parquet
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - pyarrow >=1.0
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.parquet
+
+  - name: ibis-postgres
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - sqlalchemy >=1.3
+        - psycopg2 >=2.7
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.postgres
+
+  - name: ibis-pyspark
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - lz4
+        - pyarrow >=1.0
+        - pyspark >=2.4.3
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.pyspark
+
+  - name: ibis-sqlite
+    version: {{ version }}
+
+    build:
+      script: python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+      skip: true  # [py<37]
+
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+
+      run:
+        - sqlalchemy >=1.3
+        - python
+        - {{ pin_subpackage(name + '-core', max_pin="x.x.x.x") }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.sqlite
+
 about:
   license: Apache-2.0
   license_family: Apache
@@ -107,3 +303,4 @@ extra:
     - xmnlab
     - datapythonista
     - cpcloud
+    - gforsyth


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This adds purpose-built conda packages for each of the Ibis backends not
covered in `ibis-framework-core` (excluding `mysql`, for which there is
already a standalone package, and `omniscidb` and `bigquery` which are
maintained separately).

Users can install one of these to get just the backend they need,
similar to usage of `extras_require` -- also note that multiple backend
packages can be installed alongside one another, e.g. just `ibis-dask`
and `ibis-postgres` if a user needs those two backends only.

Discussed in https://github.com/ibis-project/ibis/issues/2448
