### PR TITLE
Move packaging from prod to dev

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -253,13 +253,12 @@ outputs:
     requirements:
       run:
         - duckdb-engine
+        - packaging >=21.3
         - python-duckdb
         - sqlalchemy <2.0,>=1.4
         - {{ pin_subpackage(name + '-core') }}
 
     test:
-      requires:
-        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.duckdb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,7 @@ outputs:
         - dask >=2021.10.0
         - datafusion <0.7,>=0.4
         - duckdb-engine <1,>=0.1.8
+        - packaging >=21.3  # just necessary for duckdb backend
         - pyarrow <10,>=1
         - python-duckdb <1,>=0.3.2
         - python-graphviz <0.21,>=0.16
@@ -78,8 +79,6 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
-      requires:
-        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.dask

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 49d86a6cc32b91df057a30e8729b530e261bd5b49bce55736796acc64da72cc8
+  patches:
+    - patches/pyproject.toml.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -39,7 +41,6 @@ outputs:
         - importlib-metadata >=4
         - multipledispatch >=0.6
         - numpy >=1.15
-        - packaging >=21.3
         - pandas >=1.2.5
         - parsy >=1.3.0
         - poetry-dynamic-versioning >=0.14.0
@@ -52,6 +53,8 @@ outputs:
         - toolz >=0.11
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.pandas
@@ -75,6 +78,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.dask
@@ -98,6 +103,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.clickhouse
@@ -115,6 +122,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.dask
@@ -135,6 +144,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.impala
@@ -152,6 +163,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.mysql
@@ -169,6 +182,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.postgres
@@ -187,6 +202,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.pyspark
@@ -203,6 +220,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.sqlite
@@ -219,6 +238,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.datafusion
@@ -237,6 +258,8 @@ outputs:
         - {{ pin_subpackage(name + '-core') }}
 
     test:
+      requires:
+        - packaging >=21.3
       imports:
         - ibis
         - ibis.backends.duckdb

--- a/recipe/patches/pyproject.toml.patch
+++ b/recipe/patches/pyproject.toml.patch
@@ -1,0 +1,18 @@
+--- a/pyproject.toml	2022-09-21 11:32:50.977269119 -0400
++++ b/pyproject.toml	2022-09-21 11:49:31.945004759 -0400
+@@ -30,7 +30,6 @@
+ atpublic = ">=2.3,<4"
+ multipledispatch = ">=0.6,<0.7"
+ numpy = ">=1,<2"
+-packaging = ">=21.3,<22"
+ pandas = ">=1.2.5,<2"
+ parsy = ">=1.3.0,<3"
+ pydantic = ">=1.9.0,<2"
+@@ -106,6 +105,7 @@
+ setuptools = ">=57,<66"
+ sqlalchemy = ">=1.4,<2.0"
+ tomli = ">=2.0.1,<3"
++packaging = ">=21.3,<22"
+ 
+ [tool.poetry.extras]
+ all = [


### PR DESCRIPTION
Currently, ibis has some conflicts with poetry because the version used for "packaging"

As it is used just for tests (excepting for duckdb), I am proposing to move the "packaging" dependency to the tests section.

So we can use ibis with poetry with no problem.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
