### PR TITLE
ibis-framework v4.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--bigquery-green.svg)](https://anaconda.org/conda-forge/ibis-bigquery) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-bigquery.svg)](https://anaconda.org/conda-forge/ibis-bigquery) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-bigquery.svg)](https://anaconda.org/conda-forge/ibis-bigquery) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-bigquery.svg)](https://anaconda.org/conda-forge/ibis-bigquery) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--clickhouse-green.svg)](https://anaconda.org/conda-forge/ibis-clickhouse) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-clickhouse.svg)](https://anaconda.org/conda-forge/ibis-clickhouse) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-clickhouse.svg)](https://anaconda.org/conda-forge/ibis-clickhouse) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-clickhouse.svg)](https://anaconda.org/conda-forge/ibis-clickhouse) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--dask-green.svg)](https://anaconda.org/conda-forge/ibis-dask) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-dask.svg)](https://anaconda.org/conda-forge/ibis-dask) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-dask.svg)](https://anaconda.org/conda-forge/ibis-dask) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-dask.svg)](https://anaconda.org/conda-forge/ibis-dask) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--datafusion-green.svg)](https://anaconda.org/conda-forge/ibis-datafusion) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-datafusion.svg)](https://anaconda.org/conda-forge/ibis-datafusion) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-datafusion.svg)](https://anaconda.org/conda-forge/ibis-datafusion) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-datafusion.svg)](https://anaconda.org/conda-forge/ibis-datafusion) |
@@ -34,10 +35,13 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--framework-green.svg)](https://anaconda.org/conda-forge/ibis-framework) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-framework.svg)](https://anaconda.org/conda-forge/ibis-framework) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-framework.svg)](https://anaconda.org/conda-forge/ibis-framework) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-framework.svg)](https://anaconda.org/conda-forge/ibis-framework) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--framework--core-green.svg)](https://anaconda.org/conda-forge/ibis-framework-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-framework-core.svg)](https://anaconda.org/conda-forge/ibis-framework-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-framework-core.svg)](https://anaconda.org/conda-forge/ibis-framework-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-framework-core.svg)](https://anaconda.org/conda-forge/ibis-framework-core) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--impala-green.svg)](https://anaconda.org/conda-forge/ibis-impala) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-impala.svg)](https://anaconda.org/conda-forge/ibis-impala) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-impala.svg)](https://anaconda.org/conda-forge/ibis-impala) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-impala.svg)](https://anaconda.org/conda-forge/ibis-impala) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--mssql-green.svg)](https://anaconda.org/conda-forge/ibis-mssql) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-mssql.svg)](https://anaconda.org/conda-forge/ibis-mssql) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-mssql.svg)](https://anaconda.org/conda-forge/ibis-mssql) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-mssql.svg)](https://anaconda.org/conda-forge/ibis-mssql) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--mysql-green.svg)](https://anaconda.org/conda-forge/ibis-mysql) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-mysql.svg)](https://anaconda.org/conda-forge/ibis-mysql) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-mysql.svg)](https://anaconda.org/conda-forge/ibis-mysql) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-mysql.svg)](https://anaconda.org/conda-forge/ibis-mysql) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--postgres-green.svg)](https://anaconda.org/conda-forge/ibis-postgres) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-postgres.svg)](https://anaconda.org/conda-forge/ibis-postgres) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-postgres.svg)](https://anaconda.org/conda-forge/ibis-postgres) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-postgres.svg)](https://anaconda.org/conda-forge/ibis-postgres) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--pyspark-green.svg)](https://anaconda.org/conda-forge/ibis-pyspark) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-pyspark.svg)](https://anaconda.org/conda-forge/ibis-pyspark) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-pyspark.svg)](https://anaconda.org/conda-forge/ibis-pyspark) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-pyspark.svg)](https://anaconda.org/conda-forge/ibis-pyspark) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--snowflake-green.svg)](https://anaconda.org/conda-forge/ibis-snowflake) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-snowflake.svg)](https://anaconda.org/conda-forge/ibis-snowflake) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-snowflake.svg)](https://anaconda.org/conda-forge/ibis-snowflake) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-snowflake.svg)](https://anaconda.org/conda-forge/ibis-snowflake) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--sqlite-green.svg)](https://anaconda.org/conda-forge/ibis-sqlite) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-sqlite.svg)](https://anaconda.org/conda-forge/ibis-sqlite) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-sqlite.svg)](https://anaconda.org/conda-forge/ibis-sqlite) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-sqlite.svg)](https://anaconda.org/conda-forge/ibis-sqlite) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ibis--trino-green.svg)](https://anaconda.org/conda-forge/ibis-trino) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/ibis-trino.svg)](https://anaconda.org/conda-forge/ibis-trino) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/ibis-trino.svg)](https://anaconda.org/conda-forge/ibis-trino) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/ibis-trino.svg)](https://anaconda.org/conda-forge/ibis-trino) |
 
 Installing ibis-framework-ext
 =============================
@@ -49,41 +53,41 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `ibis-clickhouse, ibis-dask, ibis-datafusion, ibis-duckdb, ibis-framework, ibis-framework-core, ibis-impala, ibis-mysql, ibis-postgres, ibis-pyspark, ibis-sqlite` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `ibis-bigquery, ibis-clickhouse, ibis-dask, ibis-datafusion, ibis-duckdb, ibis-framework, ibis-framework-core, ibis-impala, ibis-mssql, ibis-mysql, ibis-postgres, ibis-pyspark, ibis-snowflake, ibis-sqlite, ibis-trino` can be installed with `conda`:
 
 ```
-conda install ibis-clickhouse ibis-dask ibis-datafusion ibis-duckdb ibis-framework ibis-framework-core ibis-impala ibis-mysql ibis-postgres ibis-pyspark ibis-sqlite
-```
-
-or with `mamba`:
-
-```
-mamba install ibis-clickhouse ibis-dask ibis-datafusion ibis-duckdb ibis-framework ibis-framework-core ibis-impala ibis-mysql ibis-postgres ibis-pyspark ibis-sqlite
-```
-
-It is possible to list all of the versions of `ibis-clickhouse` available on your platform with `conda`:
-
-```
-conda search ibis-clickhouse --channel conda-forge
+conda install ibis-bigquery ibis-clickhouse ibis-dask ibis-datafusion ibis-duckdb ibis-framework ibis-framework-core ibis-impala ibis-mssql ibis-mysql ibis-postgres ibis-pyspark ibis-snowflake ibis-sqlite ibis-trino
 ```
 
 or with `mamba`:
 
 ```
-mamba search ibis-clickhouse --channel conda-forge
+mamba install ibis-bigquery ibis-clickhouse ibis-dask ibis-datafusion ibis-duckdb ibis-framework ibis-framework-core ibis-impala ibis-mssql ibis-mysql ibis-postgres ibis-pyspark ibis-snowflake ibis-sqlite ibis-trino
+```
+
+It is possible to list all of the versions of `ibis-bigquery` available on your platform with `conda`:
+
+```
+conda search ibis-bigquery --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search ibis-bigquery --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search ibis-clickhouse --channel conda-forge
+mamba repoquery search ibis-bigquery --channel conda-forge
 
-# List packages depending on `ibis-clickhouse`:
-mamba repoquery whoneeds ibis-clickhouse --channel conda-forge
+# List packages depending on `ibis-bigquery`:
+mamba repoquery whoneeds ibis-bigquery --channel conda-forge
 
-# List dependencies of `ibis-clickhouse`:
-mamba repoquery depends ibis-clickhouse --channel conda-forge
+# List dependencies of `ibis-bigquery`:
+mamba repoquery depends ibis-bigquery --channel conda-forge
 ```
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,16 @@
 {% set name = "ibis-framework" %}
-{% set version = "3.2.0" %}
+{% set version = "4.0.0" %}
 
 package:
   name: {{ name }}-ext
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 49d86a6cc32b91df057a30e8729b530e261bd5b49bce55736796acc64da72cc8
-  patches:
-    - patches/pyproject.toml.patch
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
+  sha256: edefdbb6e0970a4af9e5f72dac068b1df35905cab4895e17e27b0ebb33315c09
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   host:
@@ -49,6 +47,8 @@ outputs:
         - python-graphviz >=0.16
         - regex >=2021.7.6
         - rich >=12.4.4,<13
+        - pytz >=2022.7
+        - python-dateutil >=2.8.2
         - sqlglot >=4.5.0,<7
         - toolz >=0.11
 
@@ -67,25 +67,17 @@ outputs:
 
     requirements:
       run:
-        - atpublic <4,>=2.3
-        - dask >=2021.10.0
-        - datafusion <0.7,>=0.4
-        - duckdb-engine <1,>=0.1.8
-        - packaging >=21.3  # just necessary for duckdb backend
-        - pyarrow <10,>=1
-        - python-duckdb <1,>=0.3.2
-        - python-graphviz <0.21,>=0.16
+        - duckdb-engine >=0.1.8
+        - python-duckdb >=0.3.2
         - sqlalchemy <2.0,>=1.4
+        - pyarrow >=1
+        - python-graphviz <0.21,>=0.16
         - {{ pin_subpackage(name + '-core') }}
 
     test:
       imports:
         - ibis
-        - ibis.backends.dask
-        - ibis.backends.datafusion
         - ibis.backends.duckdb
-        - ibis.backends.pandas
-        - ibis.backends.sqlite
 
 
   - name: ibis-clickhouse
@@ -178,6 +170,8 @@ outputs:
       run:
         - psycopg2 >=2.7
         - sqlalchemy <2.0,>=1.4
+        # TODO: remove after we fix the accidental import upstream
+        - pyarrow >=1.0.0
         - {{ pin_subpackage(name + '-core') }}
 
     test:
@@ -251,9 +245,8 @@ outputs:
 
     requirements:
       run:
-        - duckdb-engine
-        - packaging >=21.3
-        - python-duckdb
+        - duckdb-engine >=0.1.8
+        - python-duckdb >=0.3.2
         - sqlalchemy <2.0,>=1.4
         - {{ pin_subpackage(name + '-core') }}
 
@@ -261,6 +254,83 @@ outputs:
       imports:
         - ibis
         - ibis.backends.duckdb
+
+  - name: ibis-mssql
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      run:
+        - pymssql >=2.2.5
+        - sqlalchemy <2.0,>=1.4
+        - {{ pin_subpackage(name + '-core') }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.mssql
+
+
+  - name: ibis-bigquery
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      run:
+        - db-dtypes >=0.3.0,<2
+        - google-cloud-bigquery >=3,<4
+        - google-cloud-bigquery-storage >=2,<3
+        - pyarrow >=1.0.0
+        - pydata-google-auth
+        - sqlalchemy <2.0,>=1.4
+        - {{ pin_subpackage(name + '-core') }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.bigquery
+
+  - name: ibis-trino
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      run:
+        # TODO: remove pyarrow after fixing import issue in postgres datatypes
+        - pyarrow >=1.0.0
+        - trino-python-client >=0.319.0
+        - sqlalchemy <2.0,>=1.4
+        - {{ pin_subpackage(name + '-core') }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.trino
+
+  - name: ibis-snowflake
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      run:
+        - snowflake-connector-python >=2.7.10
+        - snowflake-sqlalchemy >=1.4.1
+        - sqlalchemy <2.0,>=1.4
+        - pandas >=1.2.5
+        - {{ pin_subpackage(name + '-core') }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.snowflake
 
 about:
   license: Apache-2.0


### PR DESCRIPTION
This updates the feedstock to Ibis 4.0.

We also add the following backends
ibis-biqquery (formerly 3rd party, now 1st party)
ibis-mssql (formerly 3rd party, now 1st party)
ibis-trino
ibis-snowflake
ibis-polars

The default `ibis-framework` package now installs the `pandas` and `duckdb` backends, for a minimal-footprint with maximal productivity (for quickstarts).

All backends still have their `ibis-<backend name>` outputs available.

I have a branch over on `feedstock-outputs` that I'll PR to update the `ibis-bigquery` and `ibis-mssql` feedstock locations.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
