### PR TITLE
fix: add pooch-extras to pick up tqdm and xxhash

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3ab78b08eeb0e7963df05fe3c21aa653d1f62d281e76e7542e2c52ac040e38eb
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -41,6 +41,7 @@ outputs:
         - pandas >=1.2.5
         - parsy >=2
         - pooch >=1.7.0
+        - pooch-extra >=1.7.0
         - poetry-dynamic-versioning >=0.18.0
         - python >=3.8
         - python-graphviz >=0.16


### PR DESCRIPTION
and paramiko.
honestly not sure if we want paramiko packed in there but it's what's available.

alternatively we can add in the extra deps ourselves.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
