### PR TITLE
fix: pin subpackage to exact version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: b9612be4da0182a7b5526592d1e5155c92b3971073d03cad8bd7ee14bf015bb1
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -69,7 +69,7 @@ outputs:
         - python-duckdb <2,>=0.8.1
         - pins <1,>=0.8.3
         - fsspec <2024.6.1
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         # - typing_extensions <5,>=4.3.0
         # - trino-python-client <1,>=0.321
         # - toolz <1,>=0.11
@@ -123,7 +123,7 @@ outputs:
     requirements:
       run:
         - clickhouse-connect >=0.5.23
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -157,7 +157,7 @@ outputs:
     requirements:
       run:
         - impyla >=0.17
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -173,7 +173,7 @@ outputs:
     requirements:
       run:
         - pymysql >=1
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -189,7 +189,7 @@ outputs:
     requirements:
       run:
         - psycopg2 >=2.8.4
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -207,7 +207,7 @@ outputs:
         - pyspark >=3
         - packaging >=21.3
         - setuptools
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -223,7 +223,7 @@ outputs:
     requirements:
       run:
         - regex >=2021.7.6
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -239,7 +239,7 @@ outputs:
     requirements:
       run:
         - datafusion >=0.6
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -257,7 +257,7 @@ outputs:
         - python-duckdb >=0.8.1
         - pins >=0.8.3
         - fsspec <2024.6.1
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -273,7 +273,7 @@ outputs:
     requirements:
       run:
         - python-duckdb >=0.8.1
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -289,7 +289,7 @@ outputs:
     requirements:
       run:
         - pyodbc >=4.0.39
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -309,7 +309,7 @@ outputs:
         - google-cloud-bigquery >=3,<4
         - google-cloud-bigquery-storage >=2,<3
         - pydata-google-auth >=1.4.0
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -325,7 +325,7 @@ outputs:
     requirements:
       run:
         - trino-python-client >=0.321
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -341,7 +341,7 @@ outputs:
     requirements:
       run:
         - snowflake-connector-python >=3.0.2
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:
       imports:
@@ -356,7 +356,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         - packaging >=21.3
         - polars >=0.20.17
 
@@ -373,7 +373,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         - pydruid >=0.6.5
         # we don't require sqlalchemy but pydruid inadvertently requires it
         - sqlalchemy >=1.4
@@ -391,7 +391,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         - oracledb >=1.3.1
         - packaging >=21.3
 
@@ -408,7 +408,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         - pyexasol >=0.25.2
 
     test:
@@ -424,7 +424,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         - apache-flink
 
     test:
@@ -440,7 +440,7 @@ outputs:
 
     requirements:
       run:
-        - {{ pin_subpackage(name + '-core') }}
+        - {{ pin_subpackage(name + '-core', exact=True) }}
         - psycopg2 >=2.8.4
 
     test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Resolves #98 