### PR TITLE
refactor: add lite variant, bump python lower bound

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -179,23 +179,6 @@ outputs:
         - ibis
         - ibis.backends.clickhouse
 
-  # - name: ibis-dask
-  #   version: {{ version }}
-
-  #   build:
-  #     noarch: python
-
-  #   requirements:
-  #     run:
-  #       - dask >=2022.9.1,<2024.3.0
-  #       - packaging >=21.3
-  #       - regex >=2021.7.6
-  #       - {{ pin_subpackage(name + '-core') }}
-
-  #   test:
-  #     imports:
-  #       - ibis
-  #       - ibis.backends.dask
 
   - name: ibis-impala
     version: {{ version }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -236,7 +236,7 @@ outputs:
 
     requirements:
       run:
-        - pyspark >=3
+        - pyspark >=3.3.3
         - packaging >=21.3
         - setuptools
         - {{ pin_subpackage(name + '-core', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -391,7 +391,7 @@ outputs:
       run:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - packaging >=21.3
-        - polars >=0.20.17
+        - polars >=1
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,10 @@ outputs:
 
     build:
       noarch: python
+      script:
+        - find . -iname "snapshots" | xargs rm -r && python -m pip install . -vv --no-deps
+      script_env:
+        - POETRY_DYNAMIC_VERSIONING_BYPASS={{ version }}
 
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
     - python >=3.10
 
 outputs:
-  - name: {{ name }}-lite
+  - name: {{ name }}-core
     version: {{ version }}
 
     build:
@@ -49,30 +49,7 @@ outputs:
       imports:
         - ibis
 
-  - name: {{ name }}-core
-    version: {{ version }}
 
-    build:
-      noarch: python
-      script:
-        - find . -iname "snapshots" | xargs rm -r && python -m pip install . -vv --no-deps
-      script_env:
-        - POETRY_DYNAMIC_VERSIONING_BYPASS={{ version }}
-
-    requirements:
-      run:
-        - numpy >=1.23.2,<3
-        - pandas >=1.5.3
-        - pyarrow >=10.0.1
-        - pyarrow-hotfix >=0.4
-        - python-graphviz >=0.16
-        - {{ pin_subpackage(name + '-lite', exact=True) }}
-
-    test:
-      imports:
-        - ibis
-        - ibis.backends.pandas
-    
   - name: {{ name }}
     version: {{ version }}
 
@@ -84,6 +61,11 @@ outputs:
         - python-duckdb <2,>=0.8.1
         - pins <1,>=0.8.3
         - fsspec <2024.6.2
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
         # - typing_extensions <5,>=4.3.0
         # - trino-python-client <1,>=0.321
         # - toolz <1,>=0.11
@@ -177,6 +159,11 @@ outputs:
       run:
         - clickhouse-connect >=0.5.23
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -194,6 +181,11 @@ outputs:
       run:
         - impyla >=0.17
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -210,6 +202,11 @@ outputs:
       run:
         - pymysql >=1
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -226,6 +223,11 @@ outputs:
       run:
         - psycopg2 >=2.8.4
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -244,6 +246,11 @@ outputs:
         - packaging >=21.3
         - setuptools
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -261,6 +268,11 @@ outputs:
         - regex >=2021.7.6
         - packaging >=21.3
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -277,6 +289,11 @@ outputs:
       run:
         - datafusion >=0.6
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -295,6 +312,11 @@ outputs:
         - pins >=0.8.3
         - fsspec <2024.6.2
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -311,6 +333,11 @@ outputs:
       run:
         - python-duckdb >=0.8.1
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -327,6 +354,11 @@ outputs:
       run:
         - pyodbc >=4.0.39
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -347,6 +379,11 @@ outputs:
         - google-cloud-bigquery-storage >=2,<3
         - pydata-google-auth >=1.4.0
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -363,6 +400,11 @@ outputs:
       run:
         - trino-python-client >=0.321
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -379,6 +421,11 @@ outputs:
       run:
         - snowflake-connector-python >=3.0.2
         - {{ pin_subpackage(name + '-core', exact=True) }}
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -396,6 +443,11 @@ outputs:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - packaging >=21.3
         - polars >=1
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -412,6 +464,11 @@ outputs:
       run:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - pydruid >=0.6.7
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -429,6 +486,11 @@ outputs:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - oracledb >=1.3.1
         - packaging >=21.3
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -445,6 +507,11 @@ outputs:
       run:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - pyexasol >=0.25.2
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -461,6 +528,11 @@ outputs:
       run:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - apache-flink
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:
@@ -477,6 +549,11 @@ outputs:
       run:
         - {{ pin_subpackage(name + '-core', exact=True) }}
         - psycopg2 >=2.8.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -289,7 +289,7 @@ outputs:
       run:
         - python-duckdb >=0.8.1
         - pins >=0.8.3
-        - fsspec <2024.6.1
+        - fsspec <2024.6.2
         - {{ pin_subpackage(name + '-core', exact=True) }}
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -407,9 +407,7 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage(name + '-core', exact=True) }}
-        - pydruid >=0.6.5
-        # we don't require sqlalchemy but pydruid inadvertently requires it
-        - sqlalchemy >=1.4
+        - pydruid >=0.6.7
 
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,14 +10,14 @@ source:
   sha256: 5e098318964d7ce53218ba9dcbf4b90d127ca3aea5fdf71661d03dc610d5df49
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:
-    - python >=3.9
+    - python >=3.10
 
 outputs:
-  - name: {{ name }}-core
+  - name: {{ name }}-lite
     version: {{ version }}
 
     build:
@@ -32,20 +32,12 @@ outputs:
         - pip
         - poetry-core >=1.0.0
         - poetry-dynamic-versioning >=0.18.0
-        - python >=3.9
+        - python >=3.10
 
       run:
         - atpublic >=2.3
-        - bidict >=0.22.1
-        - filelock >=3.7.0,<4
-        - multipledispatch >=0.6,<2
-        - numpy >=1.23.2,<3
-        - pandas >=1.5.3
         - parsy >=2
-        - pyarrow >=10.0.1
-        - pyarrow-hotfix >=0.4
-        - python >=3.9
-        - python-graphviz >=0.16
+        - python >=3.10
         - regex >=2021.7.6
         - rich >=12.4.4
         - pytz >=2022.7
@@ -56,8 +48,27 @@ outputs:
     test:
       imports:
         - ibis
-        - ibis.backends.pandas
 
+  - name: {{ name }}-core
+    version: {{ version }}
+
+    build:
+      noarch: python
+
+    requirements:
+      run:
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - python-graphviz >=0.16
+        - {{ pin_subpackage(name + '-lite', exact=True) }}
+
+    test:
+      imports:
+        - ibis
+        - ibis.backends.pandas
+    
   - name: {{ name }}
     version: {{ version }}
 
@@ -69,7 +80,6 @@ outputs:
         - python-duckdb <2,>=0.8.1
         - pins <1,>=0.8.3
         - fsspec <2024.6.2
-        - {{ pin_subpackage(name + '-core', exact=True) }}
         # - typing_extensions <5,>=4.3.0
         # - trino-python-client <1,>=0.321
         # - toolz <1,>=0.11


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

One big thing, several small things.

All the small things are dependency updates to match upstream.

The big thing is to create an additional output `ibis-framework-lite` which doesn't depend on `numpy`, `pyarrow`, or `pandas`, but can be used to build expressions and generate SQL.
This is a dependency of the (pre-existing) `ibis-framework-core` which now includes those heavier dependencies, and in turn remains a dependency of every other backend output.