### PR TITLE
relax runtime dependencies

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
   sha256: 3cf330c1f786b9d5c425f96df79cc09af7f55c63fd923bd749547c4b1bd03ae4
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -76,7 +76,6 @@ outputs:
       - python:
           imports:
             - ibis
-            - ibis.backends.duckdb
           pip_check: true
           python_version:
             - ${{ python_min }}.*
@@ -84,7 +83,6 @@ outputs:
           run:
             - pip
             - python ${{ python_min }}.*
-            - python-duckdb
         script: pip check
   - package:
       name: ibis-clickhouse

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -645,11 +645,11 @@ outputs:
         - packaging >=21.3,<25
         - fsspec
         - s3fs
-        - pyarrow >=10.0.1,
-        - pyarrow-hotfix >=0.4,
-        - numpy >=1.23.2,<3,
-        - pandas >=1.5.3,<3,
-        - rich >=12.4.4",
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -35,22 +35,12 @@ outputs:
       run:
         - python >=${{ python_min }},<${{ python_max }}
         - atpublic >=2.3
-        - bidict >=0.22.1
-        - filelock >=3.7.0,<4
-        - numpy >=1.23.2,<3
-        - packaging >=21.3
-        - pandas >=1.5.3,<3
         - parsy >=2
-        - pyarrow >=10.0.1
-        - pyarrow-hotfix >=0.4
-        - python-graphviz >=0.16
-        - regex >=2021.7.6
-        - rich >=12.4.4
-        - pytz >=2022.7
         - python-dateutil >=2.8.2
-        - sqlglot >=23.4,<26.4
+        - sqlglot >=23.4,!=26.32.0
         - toolz >=0.11,<1
         - typing-extensions >=4.3.0
+        - tzdata>=2022.7
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,6 +41,14 @@ outputs:
         - toolz >=0.11,<1
         - typing-extensions >=4.3.0
         - tzdata>=2022.7
+      run_constraints:
+        - pandas >=1.5.3,<3
+        - pyarrow >=10.0.1
+        - numpy >=1.23.2,<3
+        - packaging >=21.3
+        - rich>=12.4.4
+        - pyarrow-hotfix >=0.4
+        - packaging>=21.3
     tests:
       - python:
           imports:
@@ -52,6 +60,7 @@ outputs:
           run:
             - pip
             - python ${{ python_min }}.*
+            - packaging >=21.3
         script: pip check
   - package:
       name: ${{ name }}

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -84,6 +84,7 @@ outputs:
           run:
             - pip
             - python ${{ python_min }}.*
+            - python-duckdb
         script: pip check
   - package:
       name: ibis-clickhouse

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -72,6 +72,8 @@ outputs:
       run:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
+        - tzdata>=2022.7
+        - packaging>=21.3
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,6 +41,7 @@ outputs:
         - toolz >=0.11,<1
         - typing-extensions >=4.3.0
         - tzdata>=2022.7
+        - packaging>=21.3
       run_constraints:
         - pandas >=1.5.3,<3
         - pyarrow >=10.0.1
@@ -48,7 +49,6 @@ outputs:
         - packaging >=21.3
         - rich>=12.4.4
         - pyarrow-hotfix >=0.4
-        - packaging>=21.3
     tests:
       - python:
           imports:
@@ -60,7 +60,6 @@ outputs:
           run:
             - pip
             - python ${{ python_min }}.*
-            - packaging >=21.3
         script: pip check
   - package:
       name: ${{ name }}
@@ -73,9 +72,6 @@ outputs:
       run:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
-        - python-duckdb >=0.10.3
-        - pins >=0.8.3
-        - fsspec
     tests:
       - python:
           imports:
@@ -88,6 +84,7 @@ outputs:
           run:
             - pip
             - python ${{ python_min }}.*
+            - packaging >=21.3
         script: pip check
   - package:
       name: ibis-clickhouse
@@ -101,6 +98,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - clickhouse-connect >=0.5.23
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -126,6 +128,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - impyla >=0.17
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -146,6 +153,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - mysqlclient >=2.2.4
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -171,6 +183,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - psycopg >=3.2.0,<4
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -195,8 +212,13 @@ outputs:
       run:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
-        - pyspark >=3.3.3
+        - pyspark >=3.3.3,<4
         - packaging >=21.3,<25
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -222,6 +244,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - regex >=2021.7.6
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -247,6 +274,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - datafusion >=0.6
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -271,9 +303,14 @@ outputs:
       run:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
-        - python-duckdb >=0.10
+        - python-duckdb >=0.10,!=1.3.0
         - pins >=0.8.3,<1
-        - fsspec
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
+        - packaging >=21.3
     tests:
       - python:
           imports:
@@ -299,6 +336,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - pyodbc >=4.0.39
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -327,6 +369,12 @@ outputs:
         - google-cloud-bigquery >=3,<4
         - google-cloud-bigquery-storage >=2,<3
         - pydata-google-auth >=1.4.0,<2
+        - pandas-gbq >=0.26.1
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -352,6 +400,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - trino-python-client >=0.321
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -377,6 +430,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - snowflake-connector-python >=3.0.2
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -402,6 +460,12 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - polars >=1
+        - packaging >=21.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -427,6 +491,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - pydruid >=0.6.7
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -452,6 +521,12 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - oracledb >=1.3.1
+        - packaging>=21.3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -477,6 +552,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - pyexasol >=0.25.2
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -502,6 +582,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - apache-flink
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -527,6 +612,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - psycopg2 >=2.8.4,<3
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:
@@ -555,6 +645,11 @@ outputs:
         - packaging >=21.3,<25
         - fsspec
         - s3fs
+        - pyarrow >=10.0.1,
+        - pyarrow-hotfix >=0.4,
+        - numpy >=1.23.2,<3,
+        - pandas >=1.5.3,<3,
+        - rich >=12.4.4",
     tests:
       - python:
           imports:
@@ -580,6 +675,11 @@ outputs:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
         - databricks-sql-connector >=4.0.0,<5
+        - pyarrow >=10.0.1
+        - pyarrow-hotfix >=0.4
+        - numpy >=1.23.2,<3
+        - pandas >=1.5.3,<3
+        - rich >=12.4.4
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -40,7 +40,7 @@ outputs:
         - sqlglot >=23.4,!=26.32.0
         - toolz >=0.11,<1
         - typing-extensions >=4.3.0
-        - tzdata>=2022.7
+        - python-tzdata>=2022.7
         - packaging>=21.3
       run_constraints:
         - pandas >=1.5.3,<3
@@ -72,8 +72,6 @@ outputs:
       run:
         - python >=${{ python_min }}
         - ${{ pin_subpackage(name + '-core', exact=True) }}
-        - tzdata>=2022.7
-        - packaging>=21.3
     tests:
       - python:
           imports:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -84,7 +84,6 @@ outputs:
           run:
             - pip
             - python ${{ python_min }}.*
-            - packaging >=21.3
         script: pip check
   - package:
       name: ibis-clickhouse


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

I replicated the [pyproject.toml](https://github.com/ibis-project/ibis/blob/main/pyproject.toml) setup into the different variants.

I removed the python-duckdb test dependency from the ibis-framework package. The same test is run in the -duckdb variant.

* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
