### PR TITLE
Remove sqlglot upper version bound

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -17,7 +17,7 @@ source:
   sha256: 3cf330c1f786b9d5c425f96df79cc09af7f55c63fd923bd749547c4b1bd03ae4
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - package:
@@ -48,7 +48,7 @@ outputs:
         - rich >=12.4.4
         - pytz >=2022.7
         - python-dateutil >=2.8.2
-        - sqlglot >=23.4,<26.4
+        - sqlglot >=23.4,!=26.32.0
         - toolz >=0.11,<1
         - typing-extensions >=4.3.0
     tests:


### PR DESCRIPTION
To align with pyproject.toml

https://github.com/ibis-project/ibis/blob/main/pyproject.toml


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
